### PR TITLE
Added a test for Queueable event listeners and added an UnknownEvent

### DIFF
--- a/src/Events/DispatcherAdapter.php
+++ b/src/Events/DispatcherAdapter.php
@@ -47,7 +47,7 @@ class DispatcherAdapter implements EventDispatcherInterface
     private function translateEvent(?string $eventName, object $symfonyEvent): object
     {
         if (is_null($eventName)) {
-            return $symfonyEvent;
+            return new UnknownEvent($symfonyEvent);
         }
 
         $eventNameParts = explode('.', $eventName);
@@ -58,12 +58,12 @@ class DispatcherAdapter implements EventDispatcherInterface
             $event = $eventNameParts[2];
         } else {
             // fallback if unknown event name
-            return $symfonyEvent;
+            return new UnknownEvent($symfonyEvent);
         }
 
         if (! array_key_exists($event, static::EVENT_MAP)) {
             // fallback for no mapped event known
-            return $symfonyEvent;
+            return new UnknownEvent($symfonyEvent);
         }
 
         $translatedEventClass = static::EVENT_MAP[$event];

--- a/src/Events/DispatcherAdapter.php
+++ b/src/Events/DispatcherAdapter.php
@@ -47,13 +47,13 @@ class DispatcherAdapter implements EventDispatcherInterface
     private function translateEvent(?string $eventName, object $symfonyEvent): object
     {
         if (is_null($eventName)) {
-            return new UnknownEvent($symfonyEvent);
+            return new WorkflowEvent($symfonyEvent);
         }
 
         $event = $this->parseWorkflowEventFromEventName($eventName);
 
         if (! $event) {
-            return new UnknownEvent($symfonyEvent);
+            return new WorkflowEvent($symfonyEvent);
         }
 
         $translatedEventClass = static::EVENT_MAP[$event];

--- a/src/Events/DispatcherAdapter.php
+++ b/src/Events/DispatcherAdapter.php
@@ -3,7 +3,6 @@
 namespace ZeroDaHero\LaravelWorkflow\Events;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Symfony\Component\Workflow\Event\Event as SymfonyWorkflowEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class DispatcherAdapter implements EventDispatcherInterface

--- a/src/Events/UnknownEvent.php
+++ b/src/Events/UnknownEvent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ZeroDaHero\LaravelWorkflow\Events;
+
+class UnknownEvent extends BaseEvent
+{
+}

--- a/src/Events/WorkflowEvent.php
+++ b/src/Events/WorkflowEvent.php
@@ -2,6 +2,6 @@
 
 namespace ZeroDaHero\LaravelWorkflow\Events;
 
-class UnknownEvent extends BaseEvent
+class WorkflowEvent extends BaseEvent
 {
 }

--- a/tests/DispatchAdapterTest.php
+++ b/tests/DispatchAdapterTest.php
@@ -19,6 +19,7 @@ use ZeroDaHero\LaravelWorkflow\Events\EnterEvent;
 use ZeroDaHero\LaravelWorkflow\Events\GuardEvent;
 use ZeroDaHero\LaravelWorkflow\Events\LeaveEvent;
 use ZeroDaHero\LaravelWorkflow\Events\TransitionEvent;
+use ZeroDaHero\LaravelWorkflow\Events\UnknownEvent;
 
 class DispatchAdapterTest extends TestCase
 {
@@ -94,7 +95,7 @@ class DispatchAdapterTest extends TestCase
             }
 
             yield "No event name ${eventType}" => [
-                get_class($symfonyEvent),
+                UnknownEvent::class,
                 $symfonyEvent,
                 null,
                 get_class($symfonyEvent),

--- a/tests/DispatchAdapterTest.php
+++ b/tests/DispatchAdapterTest.php
@@ -19,7 +19,7 @@ use ZeroDaHero\LaravelWorkflow\Events\EnterEvent;
 use ZeroDaHero\LaravelWorkflow\Events\GuardEvent;
 use ZeroDaHero\LaravelWorkflow\Events\LeaveEvent;
 use ZeroDaHero\LaravelWorkflow\Events\TransitionEvent;
-use ZeroDaHero\LaravelWorkflow\Events\UnknownEvent;
+use ZeroDaHero\LaravelWorkflow\Events\WorkflowEvent;
 
 class DispatchAdapterTest extends TestCase
 {
@@ -103,7 +103,7 @@ class DispatchAdapterTest extends TestCase
                 }
 
                 yield "No event name ${eventType} (${dotScenario})" => [
-                    UnknownEvent::class,
+                    WorkflowEvent::class,
                     $symfonyEvent,
                     null,
                     get_class($symfonyEvent),

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -103,7 +103,7 @@ class EventTest extends TestCase
     {
         $app['config']['workflow'] = [
             'straight' => [
-                'type' => 'state_machine',
+                'type' => 'workflow',
                 'marking_store' => [
                     'type' => 'single_state',
                 ],
@@ -123,7 +123,7 @@ class EventTest extends TestCase
                 ],
             ],
             'straight.test' => [
-                'type' => 'state_machine',
+                'type' => 'workflow',
                 'marking_store' => [
                     'type' => 'single_state',
                 ],

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests;
 
+use Event;
 use Orchestra\Testbench\TestCase;
 use Tests\Fixtures\TestModel;
+use Tests\Fixtures\TestEloquentModel;
+use Tests\Fixtures\TestWorkflowListener;
 use Workflow;
 use ZeroDaHero\LaravelWorkflow\Events\TransitionEvent;
 use ZeroDaHero\LaravelWorkflow\Facades\WorkflowFacade;
@@ -64,6 +67,19 @@ class EventTest extends TestCase
         $this->assertNull($event->doSomethingUndefined());
     }
 
+    /**
+     * @test
+     */
+    public function testQueueableEvents()
+    {
+        Event::listen('workflow.straight.test.transition.to_there', [TestWorkflowListener::class, 'handle']);
+        $subject = app(TestEloquentModel::class);
+        $workflow = Workflow::get($subject, 'straight.test');
+        $this->assertTrue($subject->workflow_can('to_there', 'straight.test'));
+        $subject->workflow_apply('to_there', 'straight.test');
+        $this->assertEquals('there', $subject->marking);
+    }
+
     protected function getPackageProviders($app)
     {
         return [WorkflowServiceProvider::class];
@@ -87,11 +103,33 @@ class EventTest extends TestCase
     {
         $app['config']['workflow'] = [
             'straight' => [
-                'type' => 'workflow',
+                'type' => 'state_machine',
                 'marking_store' => [
                     'type' => 'single_state',
                 ],
-                'supports' => ['Tests\Fixtures\TestModel'],
+                'supports' => [
+                    TestModel::class,
+                ],
+                'places' => ['here', 'there', 'somewhere'],
+                'transitions' => [
+                    'to_there' => [
+                        'from' => 'here',
+                        'to' => 'there',
+                    ],
+                    'to_somewhere' => [
+                        'from' => 'there',
+                        'to' => 'somewhere',
+                    ],
+                ],
+            ],
+            'straight.test' => [
+                'type' => 'state_machine',
+                'marking_store' => [
+                    'type' => 'single_state',
+                ],
+                'supports' => [
+                    TestEloquentModel::class,
+                ],
                 'places' => ['here', 'there', 'somewhere'],
                 'transitions' => [
                     'to_there' => [

--- a/tests/Fixtures/TestEloquentModel.php
+++ b/tests/Fixtures/TestEloquentModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use ZeroDaHero\LaravelWorkflow\Traits\WorkflowTrait;
+
+class TestEloquentModel extends Model
+{
+    use WorkflowTrait;
+
+    public $marking = 'here';
+}

--- a/tests/Fixtures/TestWorkflowListener.php
+++ b/tests/Fixtures/TestWorkflowListener.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class TestWorkflowListener implements ShouldQueue
+{
+    public function handle($event)
+    {
+        // NOTE: This doesn't need to do anything as we are just ensuring that the event
+        //       can be serialized and dispatched to a queue.
+    }
+}

--- a/tests/Fixtures/TestWorkflowListener.php
+++ b/tests/Fixtures/TestWorkflowListener.php
@@ -6,9 +6,13 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 
 class TestWorkflowListener implements ShouldQueue
 {
+    /**
+     * @return void
+     */
     public function handle($event)
     {
         // NOTE: This doesn't need to do anything as we are just ensuring that the event
         //       can be serialized and dispatched to a queue.
+        return;
     }
 }


### PR DESCRIPTION
This update prevents the attempted serialisation of closures when registered event listeners implement the `Illuminate\Contracts\Queue\ShouldQueue` interface.

Fixes #44 