### PR TITLE
Use StateMachineGraphvizDumper to dump state machines

### DIFF
--- a/src/Commands/WorkflowDumpCommand.php
+++ b/src/Commands/WorkflowDumpCommand.php
@@ -8,6 +8,8 @@ use Illuminate\Console\Command;
 use Storage;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Workflow\Dumper\GraphvizDumper;
+use Symfony\Component\Workflow\Dumper\StateMachineGraphvizDumper;
+use Symfony\Component\Workflow\StateMachine;
 use Workflow;
 
 /**
@@ -68,6 +70,9 @@ class WorkflowDumpCommand extends Command
         $definition = $workflow->getDefinition();
 
         $dumper = new GraphvizDumper();
+        if ($workflow instanceof StateMachine) {
+            $dumper = new StateMachineGraphvizDumper();
+        }
 
         $dotCommand = ['dot', "-T${format}", '-o', "${workflowName}.${format}"];
 


### PR DESCRIPTION
This change uses the StateMachineGraphvizDumper dumper
to output workflows who's config have `type = 'state_machine'`,
resulting in a nicer image than with the standard dumper.

Before:

![before](https://user-images.githubusercontent.com/58074/121711567-9a223800-ca8f-11eb-9997-9aa1ad4867d3.png)

After:

![after](https://user-images.githubusercontent.com/58074/121711581-9e4e5580-ca8f-11eb-861b-80a5656a94fc.png)
