### PR TITLE
Fixed error when install on L9, symfony/event-dispatcher-contracts 2.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.4|^8.0|^8.1",
         "symfony/workflow": "^6.0",
         "symfony/process": "^6.0",
-        "symfony/event-dispatcher-contracts": "^2.4",
+        "symfony/event-dispatcher-contracts": "^2.4|^3.0",
         "illuminate/console": "^8.0|^9.0",
         "illuminate/support": "^8.0|^9.0",
         "illuminate/contracts": "^8.0|^9.0"


### PR DESCRIPTION
…4 conflict with 3.0 from L9 requirement