### PR TITLE
Fixes PHP 8.2 deprecation warnings

### DIFF
--- a/src/Commands/WorkflowDumpCommand.php
+++ b/src/Commands/WorkflowDumpCommand.php
@@ -61,11 +61,11 @@ class WorkflowDumpCommand extends Command
         }
 
         if (! isset($config[$workflowName])) {
-            throw new Exception("Workflow ${workflowName} is not configured.");
+            throw new Exception("Workflow {$workflowName} is not configured.");
         }
 
         if (false === array_search($class, $config[$workflowName]['supports'])) {
-            throw new Exception("Workflow ${workflowName} has no support for class ${class}." .
+            throw new Exception("Workflow {$workflowName} has no support for class {$class}." .
                 ' Please specify a valid support class with the --class option.');
         }
 
@@ -79,7 +79,7 @@ class WorkflowDumpCommand extends Command
             $dumper = new StateMachineGraphvizDumper();
         }
 
-        $dotCommand = ['dot', "-T${format}", '-o', "${workflowName}.${format}"];
+        $dotCommand = ['dot', "-T{$format}", '-o', "{$workflowName}.{$format}"];
 
         $process = new Process($dotCommand);
         $process->setWorkingDirectory($path);

--- a/src/Events/DispatcherAdapter.php
+++ b/src/Events/DispatcherAdapter.php
@@ -25,7 +25,7 @@ class DispatcherAdapter implements EventDispatcherInterface
     {
         $this->dispatcher = $dispatcher;
         $this->plainEvents = array_map(function ($event) {
-            return "workflow.${event}";
+            return "workflow.{$event}";
         }, array_keys(static::EVENT_MAP));
     }
 

--- a/src/WorkflowServiceProvider.php
+++ b/src/WorkflowServiceProvider.php
@@ -21,8 +21,8 @@ class WorkflowServiceProvider extends ServiceProvider
         $configPath = $this->configPath();
 
         $this->publishes([
-            "${configPath}/workflow.php" => $this->publishPath('workflow.php'),
-            "${configPath}/workflow_registry.php" => $this->publishPath('workflow_registry.php'),
+            "{$configPath}/workflow.php" => $this->publishPath('workflow.php'),
+            "{$configPath}/workflow_registry.php" => $this->publishPath('workflow_registry.php'),
         ], 'config');
     }
 

--- a/tests/DispatchAdapterTest.php
+++ b/tests/DispatchAdapterTest.php
@@ -101,11 +101,11 @@ class DispatchAdapterTest extends TestCase
                 $symfonyEvent = new $symfonyEvent(new stdClass(), new Marking(), new Transition($transition, [], []), $mockWorkflow);
 
                 foreach ([
-                    "workflow.${eventType}",
-                    "workflow.${name}.${eventType}",
-                    "workflow.${name}.${eventType}.${transition}",
+                    "workflow.{$eventType}",
+                    "workflow.{$name}.{$eventType}",
+                    "workflow.{$name}.{$eventType}.{$transition}",
                 ] as $eventName) {
-                    yield "${eventName} (${dotScenario})" => [
+                    yield "{$eventName} ({$dotScenario})" => [
                         $expectedEventClass,
                         $symfonyEvent,
                         $eventName,
@@ -113,7 +113,7 @@ class DispatchAdapterTest extends TestCase
                     ];
                 }
 
-                yield "No event name ${eventType} (${dotScenario})" => [
+                yield "No event name {$eventType} ({$dotScenario})" => [
                     WorkflowEvent::class,
                     $symfonyEvent,
                     null,

--- a/tests/WorkflowEventsTest.php
+++ b/tests/WorkflowEventsTest.php
@@ -181,7 +181,7 @@ class WorkflowEventsTest extends BaseWorkflowTestCase
         ];
 
         foreach ($events as $key => $event) {
-            yield "silences ${event}" => [[$event], [$key]];
+            yield "silences {$event}" => [[$event], [$key]];
         }
     }
 


### PR DESCRIPTION
Fixed in all places.

```
WARN  PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead in vendor/zerodahero/laravel-workflow/src/WorkflowServiceProvider.php on line 24.  
WARN  PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead in vendor/zerodahero/laravel-workflow/src/WorkflowServiceProvider.php on line 25.

etc
```