### PR TITLE
Expose isLoaded method on the facade

### DIFF
--- a/src/WorkflowRegistry.php
+++ b/src/WorkflowRegistry.php
@@ -222,7 +222,7 @@ class WorkflowRegistry
      *
      * @return bool
      */
-    protected function isLoaded($workflowName, $supportStrategy)
+    public function isLoaded($workflowName, $supportStrategy)
     {
         if (! $this->registryConfig['track_loaded']) {
             return false;


### PR DESCRIPTION
Currently the `isLoaded` method is not accessible outside of the facade, this changes that. I would like to be able to check if a workflow is loaded before fetching it from the database. 