### PR TITLE
Add getter for property name on marking store

### DIFF
--- a/src/MarkingStores/EloquentMarkingStore.php
+++ b/src/MarkingStores/EloquentMarkingStore.php
@@ -67,4 +67,14 @@ class EloquentMarkingStore implements MarkingStoreInterface
         // If the mutator doesn't exist, defer to Eloquent for setting/casting/etc
         $subject->{$this->property} = $marking;
     }
+
+    /**
+     * Return the property name of the marking
+     *
+     * @return mixed
+     */
+    public function getProperty()
+    {
+        return $this->property;
+    }
 }


### PR DESCRIPTION
Adds a getter for the property name on the marking store. My use case is automatically determining the workflows needed to run based on properties changed on a model, but requires knowing the property name