### PR TITLE
make  EloquentMarkingStore::getMarking compatible with Symfony MethodMarkingStore

### DIFF
--- a/src/MarkingStores/EloquentMarkingStore.php
+++ b/src/MarkingStores/EloquentMarkingStore.php
@@ -2,6 +2,7 @@
 
 namespace ZeroDaHero\LaravelWorkflow\MarkingStores;
 
+use Symfony\Component\Translation\Exception\LogicException;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 
@@ -39,6 +40,8 @@ class EloquentMarkingStore implements MarkingStoreInterface
 
         if ($this->singleState) {
             $marking = [(string) $marking => 1];
+        } else if (!\is_array($marking)) {
+            throw new LogicException(sprintf('The marking stored in "%s::$%s" is not an array and the Workflow\'s Marking store is instantiated with $singleState=false.', get_debug_type($subject), $this->property));
         }
 
         return new Marking($marking);


### PR DESCRIPTION
As of symfony 's MethodMarkingStore implemtentation, when marking_store is not single_state and marking store property is not an array, exception thrown. So I add this to EloquentMarkingStore.