### PR TITLE
Add `--with-metadata` support for workflow:dump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,10 @@ You can change the image format with the `--format` option. By default the forma
 
     php artisan workflow:dump workflow_name --format=jpg
 
+Similar to [Symfony](https://symfony.com/doc/current/workflow/dumping-workflows.html#styling). You can use `--with-metadata` to include workflow's metadata
+
+    php artisan workflow:dump workflow_name --with-metadata
+
 If you would like to output to a different directory than root, you can use the `--disk` and `--path` options to set the Storage disk (`local` by default) and path (`root_path()` by default).
 
     php artisan workflow:dump workflow-name --class=App\\BlogPost --disk=s3 --path="workflows/diagrams/"

--- a/src/Commands/WorkflowDumpCommand.php
+++ b/src/Commands/WorkflowDumpCommand.php
@@ -27,7 +27,8 @@ class WorkflowDumpCommand extends Command
         {--class= : the support class name}
         {--format=png : the image format}
         {--disk=local : the storage disk name}
-        {--path= : the optional path within selected disk}';
+        {--path= : the optional path within selected disk}
+        {--with-metadata : dumps metadata beneath the label }';
 
     /**
      * The console command description.
@@ -50,6 +51,7 @@ class WorkflowDumpCommand extends Command
         $config = Config::get('workflow');
         $disk = $this->option('disk');
         $optionalPath = $this->option('path');
+        $withMetadata = $this->option('with-metadata');
 
         if ($disk === 'local') {
             $optionalPath ??= '.';
@@ -69,6 +71,10 @@ class WorkflowDumpCommand extends Command
                 ' Please specify a valid support class with the --class option.');
         }
 
+        $dumper_options = [
+            'with-metadata' => $withMetadata,
+        ];
+
         $subject = new $class();
         $workflow = Workflow::get($subject, $workflowName);
         $definition = $workflow->getDefinition();
@@ -83,7 +89,7 @@ class WorkflowDumpCommand extends Command
 
         $process = new Process($dotCommand);
         $process->setWorkingDirectory($path);
-        $process->setInput($dumper->dump($definition));
+        $process->setInput($dumper->dump($definition, options: $dumper_options));
         $process->mustRun();
     }
 }

--- a/src/Commands/WorkflowDumpCommand.php
+++ b/src/Commands/WorkflowDumpCommand.php
@@ -71,7 +71,7 @@ class WorkflowDumpCommand extends Command
                 ' Please specify a valid support class with the --class option.');
         }
 
-        $dumper_options = [
+        $dumperOptions = [
             'with-metadata' => $withMetadata,
         ];
 
@@ -89,7 +89,7 @@ class WorkflowDumpCommand extends Command
 
         $process = new Process($dotCommand);
         $process->setWorkingDirectory($path);
-        $process->setInput($dumper->dump($definition, options: $dumper_options));
+        $process->setInput($dumper->dump($definition, options: $dumperOptions));
         $process->mustRun();
     }
 }

--- a/tests/WorkflowDumpCommandTest.php
+++ b/tests/WorkflowDumpCommandTest.php
@@ -4,61 +4,30 @@ namespace Tests;
 
 use Mockery;
 use Illuminate\Support\Facades\Storage;
+use Mockery\MockInterface;
 use ZeroDaHero\LaravelWorkflow\Commands\WorkflowDumpCommand;
 
 class WorkflowDumpCommandTest extends BaseWorkflowTestCase
 {
     public function testShouldThrowExceptionForUndefinedWorkflow()
     {
-        $command = Mockery::mock(WorkflowDumpCommand::class)
-            ->makePartial()
-            ->shouldReceive('argument')
-            ->with('workflow')
-            ->andReturn('fake')
-            ->shouldReceive('option')
-            ->with('format')
-            ->andReturn('png')
-            ->shouldReceive('option')
-            ->with('class')
-            ->andReturn('Tests\Fixtures\TestObject')
-            ->shouldReceive('option')
-            ->with('disk')
-            ->andReturn('local')
-            ->shouldReceive('option')
-            ->with('path')
-            ->andReturn('/')
-            ->getMock();
+        $command = $this->getMock(workflow: 'fake');
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Workflow fake is not configured.');
+
         $command->handle();
     }
 
     public function testShouldThrowExceptionForUndefinedClass()
     {
-        $command = Mockery::mock(WorkflowDumpCommand::class)
-            ->makePartial()
-            ->shouldReceive('argument')
-            ->with('workflow')
-            ->andReturn('straight')
-            ->shouldReceive('option')
-            ->with('format')
-            ->andReturn('png')
-            ->shouldReceive('option')
-            ->with('class')
-            ->andReturn('Tests\Fixtures\FakeObject')
-            ->shouldReceive('option')
-            ->with('disk')
-            ->andReturn('local')
-            ->shouldReceive('option')
-            ->with('path')
-            ->andReturn('/')
-            ->getMock();
+        $command = $this->getMock(class: 'Tests\Fixtures\FakeObject');
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Workflow straight has no support for' .
             ' class Tests\Fixtures\FakeObject. Please specify a valid support' .
             ' class with the --class option.');
+
         $command->handle();
     }
 
@@ -73,28 +42,42 @@ class WorkflowDumpCommandTest extends BaseWorkflowTestCase
             Storage::disk($disk)->delete($optionalPath . '/straight.png');
         }
 
-        $command = Mockery::mock(WorkflowDumpCommand::class)
+        $command = $this->getMock(disk: $disk, path: $optionalPath);
+        $command->handle();
+
+        Storage::disk($disk)->assertExists($optionalPath . '/straight.png');
+    }
+
+    private function getMock(
+        string $workflow = 'straight',
+        string $format = 'png',
+        string $class = 'Tests\Fixtures\TestObject',
+        string $disk = 'local',
+        string $path = '/',
+        bool $withMetadata = false,
+    ): MockInterface
+    {
+        return Mockery::mock(WorkflowDumpCommand::class)
             ->makePartial()
             ->shouldReceive('argument')
             ->with('workflow')
-            ->andReturn('straight')
+            ->andReturn($workflow)
             ->shouldReceive('option')
             ->with('format')
-            ->andReturn('png')
+            ->andReturn($format)
             ->shouldReceive('option')
             ->with('class')
-            ->andReturn('Tests\Fixtures\TestObject')
+            ->andReturn($class)
             ->shouldReceive('option')
             ->with('disk')
             ->andReturn($disk)
             ->shouldReceive('option')
             ->with('path')
-            ->andReturn($optionalPath)
+            ->andReturn($path)
+            ->shouldReceive('option')
+            ->with('with-metadata')
+            ->andReturn($withMetadata)
             ->getMock();
-
-        $command->handle();
-
-        Storage::disk($disk)->assertExists($optionalPath . '/straight.png');
     }
 
     protected function getEnvironmentSetUp($app)


### PR DESCRIPTION
Hopefully its explained in the README changes.

Largely just exposing symfony's `--with-metadata` option for dumping workflow