### PR TITLE
Preserve context in non guard events

### DIFF
--- a/src/Events/GuardEvent.php
+++ b/src/Events/GuardEvent.php
@@ -52,12 +52,7 @@ class GuardEvent extends BaseEvent
      */
     public static function newFromBase(Event $symfonyEvent)
     {
-        $instance = new static(
-            $symfonyEvent->getSubject(),
-            $symfonyEvent->getMarking(),
-            $symfonyEvent->getTransition(),
-            $symfonyEvent->getWorkflow()
-        );
+        $instance = parent::newFromBase($symfonyEvent);
 
         $instance->symfonyProxyEvent = $symfonyEvent;
 


### PR DESCRIPTION
The context was not always preserved in non guard events.