### PR TITLE
PHP 8.4 support

### DIFF
--- a/src/Events/GuardEvent.php
+++ b/src/Events/GuardEvent.php
@@ -21,7 +21,7 @@ class GuardEvent extends BaseEvent
 {
     private SymfonyGuardEvent $symfonyProxyEvent;
 
-    public function __construct(object $subject, Marking $marking, Transition $transition, WorkflowInterface $workflow = null)
+    public function __construct(object $subject, Marking $marking, Transition $transition, ?WorkflowInterface $workflow = null)
     {
         parent::__construct($subject, $marking, $transition, $workflow);
 

--- a/src/WorkflowRegistry.php
+++ b/src/WorkflowRegistry.php
@@ -57,7 +57,7 @@ class WorkflowRegistry
      *
      * @throws \ReflectionException
      */
-    public function __construct(array $config, array $registryConfig = null, EventsDispatcher $laravelDispatcher)
+    public function __construct(array $config, ?array $registryConfig = null, EventsDispatcher $laravelDispatcher)
     {
         $this->registry = new Registry();
         $this->config = $config;

--- a/src/WorkflowRegistry.php
+++ b/src/WorkflowRegistry.php
@@ -57,7 +57,7 @@ class WorkflowRegistry
      *
      * @throws \ReflectionException
      */
-    public function __construct(array $config, ?array $registryConfig = null, EventsDispatcher $laravelDispatcher)
+    public function __construct(array $config, ?array $registryConfig, EventsDispatcher $laravelDispatcher)
     {
         $this->registry = new Registry();
         $this->config = $config;


### PR DESCRIPTION
Adds support for PHP 8.4. Prior to these changes, the following deprecations would be logged when accessing this package:
```
ZeroDaHero\LaravelWorkflow\WorkflowRegistry::__construct(): Implicitly marking parameter $registryConfig as nullable is deprecated, the explicit nullable type must be used instead
ZeroDaHero\LaravelWorkflow\WorkflowRegistry::__construct(): Optional parameter $registryConfig declared before required parameter $laravelDispatcher is implicitly treated as a required parameter
ZeroDaHero\LaravelWorkflow\Events\GuardEvent::__construct(): Implicitly marking parameter $workflow as nullable is deprecated, the explicit nullable type must be used instead
```