### PR TITLE
Add laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,12 +13,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.1, 8.2, 8.3, 8.4]
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         stability: [prefer-stable]
         exclude:
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*
+            php: 8.1
+          - laravel: 13.*
             php: 8.1
           - laravel: 10.*
             php: 8.4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,6 +22,8 @@ jobs:
             php: 8.1
           - laravel: 13.*
             php: 8.1
+          - laravel: 13.*
+            php: 8.2
           - laravel: 10.*
             php: 8.4
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .php_cs
 .php_cs.cache
 .phpunit.result.cache
+.phpunit.cache
 .vscode
 composer.lock
 tests/coverage

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,10 @@
         "workflow",
         "symfony",
         "laravel",
-        "laravel7",
-        "laravel8"
+        "laravel10",
+        "laravel11",
+        "laravel12",
+        "laravel13"
     ],
     "license": "MIT",
     "require": {
@@ -14,9 +16,9 @@
         "symfony/workflow": "^6.0|^7.0",
         "symfony/process": "^6.0|^7.0",
         "symfony/event-dispatcher-contracts": "^2.4|^3.0",
-        "illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {
@@ -43,10 +45,10 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.2",
-        "phpunit/phpunit": "^9.0|^10.5|^11.5.3",
+        "phpunit/phpunit": "^9.0|^10.5|^11.0|^12.0",
         "symfony/var-dumper": "^6.0|^7.0",
         "fakerphp/faker": "^1.13|^1.9.1",
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "symfony/contracts": "^2.3|^3.5"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,8 +5,7 @@
   bootstrap="vendor/autoload.php"
   colors="true"
   processIsolation="false"
-  stopOnFailure="false"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
   cacheDirectory=".phpunit.cache"
   backupStaticProperties="false"
 >

--- a/tests/DispatchAdapterTest.php
+++ b/tests/DispatchAdapterTest.php
@@ -7,7 +7,6 @@ use stdClass;
 use PHPUnit\Framework\TestCase;
 use Tests\Helpers\CanAccessProtected;
 use Symfony\Component\Workflow\Marking;
-use Symfony\Component\Workflow\Workflow;
 use Symfony\Component\Workflow\Transition;
 use Illuminate\Contracts\Events\Dispatcher;
 use ZeroDaHero\LaravelWorkflow\Events\BaseEvent;
@@ -20,6 +19,7 @@ use ZeroDaHero\LaravelWorkflow\Events\AnnounceEvent;
 use ZeroDaHero\LaravelWorkflow\Events\WorkflowEvent;
 use ZeroDaHero\LaravelWorkflow\Events\CompletedEvent;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ZeroDaHero\LaravelWorkflow\Events\TransitionEvent;
 use ZeroDaHero\LaravelWorkflow\Events\DispatcherAdapter;
 
@@ -28,19 +28,7 @@ class DispatchAdapterTest extends TestCase
     use CanAccessProtected;
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @test
-     *
-     * @dataProvider providesEventScenarios
-     *
-     * @param mixed $expectedEvent
-     * @param mixed $event
-     * @param mixed $eventName
-     * @param mixed $expectedPackageEvent
-     * @param mixed $symfonyEvent
-     * @param mixed $eventDotName
-     * @param mixed $expectedDotName
-     */
+    #[DataProvider('providesEventScenarios')]
     public function testAdaptsSymfonyEventsToLaravel($expectedPackageEvent, $symfonyEvent, $eventDotName, $expectedDotName)
     {
         $mockDispatcher = Mockery::mock(Dispatcher::class);

--- a/tests/Helpers/CanAccessProtected.php
+++ b/tests/Helpers/CanAccessProtected.php
@@ -19,7 +19,6 @@ trait CanAccessProtected
     {
         $reflection = new ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);
-        $method->setAccessible(true);
 
         return $method->invokeArgs($object, $parameters);
     }
@@ -35,7 +34,6 @@ trait CanAccessProtected
     public function getProtectedProperty(&$object, $propertyName)
     {
         $property = (new ReflectionClass($object))->getProperty($propertyName);
-        $property->setAccessible(true);
 
         return $property->getValue($object);
     }

--- a/tests/MarkingStores/EloquentMarkingStoreTest.php
+++ b/tests/MarkingStores/EloquentMarkingStoreTest.php
@@ -4,6 +4,7 @@ namespace Tests\MarkingStores;
 
 use Tests\Fixtures\TestModel;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\Fixtures\TestModelMutator;
 use Symfony\Component\Workflow\Marking;
 use ZeroDaHero\LaravelWorkflow\MarkingStores\EloquentMarkingStore;
@@ -17,13 +18,7 @@ class EloquentMarkingStoreTest extends TestCase
         $this->faker = \Faker\Factory::create();
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider providesSubjects
-     *
-     * @param mixed $subject
-     */
+    #[DataProvider('providesSubjects')]
     public function testSingleStateMarking($subject)
     {
         $store = new EloquentMarkingStore(true, 'marking');
@@ -49,13 +44,7 @@ class EloquentMarkingStoreTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider providesSubjects
-     *
-     * @param mixed $subject
-     */
+    #[DataProvider('providesSubjects')]
     public function testMultiStateMarking($subject)
     {
         $store = new EloquentMarkingStore(false, 'marking');
@@ -73,15 +62,7 @@ class EloquentMarkingStoreTest extends TestCase
         $this->assertEquals($newMarking, $setMarking->getPlaces());
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider providesTypeSafeScenarios
-     *
-     * @param mixed $markingValue
-     * @param mixed $expectedMarkingValue
-     * @param mixed $expectedMarkingKey
-     */
+    #[DataProvider('providesTypeSafeScenarios')]
     public function testTypeSafeMarkings($markingValue, $expectedMarkingKey)
     {
         $store = new EloquentMarkingStore(true, 'marking');

--- a/tests/WorkflowEventsTest.php
+++ b/tests/WorkflowEventsTest.php
@@ -14,6 +14,7 @@ use ZeroDaHero\LaravelWorkflow\Events\AnnounceEvent;
 use ZeroDaHero\LaravelWorkflow\Events\CompletedEvent;
 use ZeroDaHero\LaravelWorkflow\Events\TransitionEvent;
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcher;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Workflow\Exception\NotEnabledTransitionException;
 
 class WorkflowEventsTest extends BaseWorkflowTestCase
@@ -119,11 +120,7 @@ class WorkflowEventsTest extends BaseWorkflowTestCase
         $this->assertEventSetDispatched('guard', 't2');
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider providesEventsToDispatchScenarios
-     */
+    #[DataProvider('providesEventsToDispatchScenarios')]
     public function testIfWorkflowOnlyEmitsSpecificEvents(?array $eventsToDispatch, array $eventsToExpect)
     {
         Event::fake();

--- a/tests/WorkflowRegistryTest.php
+++ b/tests/WorkflowRegistryTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Workflow\Workflow;
 use Symfony\Component\Workflow\StateMachine;
 use ZeroDaHero\LaravelWorkflow\WorkflowRegistry;
 use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ZeroDaHero\LaravelWorkflow\MarkingStores\EloquentMarkingStore;
 
 class WorkflowRegistryTest extends BaseWorkflowTestCase
@@ -51,8 +52,6 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $workflow = $registry->get($subject);
 
         $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
-        $markingStoreProp->setAccessible(true);
-
         $markingStore = $markingStoreProp->getValue($workflow);
 
         $this->assertInstanceof(Workflow::class, $workflow);
@@ -90,8 +89,6 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $workflow = $registry->get($subject);
 
         $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
-        $markingStoreProp->setAccessible(true);
-
         $markingStore = $markingStoreProp->getValue($workflow);
 
         $this->assertInstanceOf(StateMachine::class, $workflow);
@@ -130,8 +127,6 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $workflow = $registry->get($subject);
 
         $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
-        $markingStoreProp->setAccessible(true);
-
         $markingStore = $markingStoreProp->getValue($workflow);
 
         $this->assertInstanceOf(StateMachine::class, $workflow);
@@ -173,8 +168,6 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $workflow = $registry->get($subject);
 
         $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
-        $markingStoreProp->setAccessible(true);
-
         $markingStore = $markingStoreProp->getValue($workflow);
 
         $this->assertInstanceof(StateMachine::class, $workflow);
@@ -220,8 +213,6 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $workflow = $registry->get($subject);
 
         $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
-        $markingStoreProp->setAccessible(true);
-
         $markingStore = $markingStoreProp->getValue($workflow);
 
         $this->assertInstanceof(StateMachine::class, $workflow);
@@ -262,8 +253,6 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $workflow = $registry->get($subject);
 
         $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
-        $markingStoreProp->setAccessible(true);
-
         $markingStore = $markingStoreProp->getValue($workflow);
 
         $this->assertInstanceof(Workflow::class, $workflow);
@@ -304,8 +293,6 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $workflow = $registry->get($subject);
 
         $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
-        $markingStoreProp->setAccessible(true);
-
         $markingStore = $markingStoreProp->getValue($workflow);
 
         $this->assertInstanceof(Workflow::class, $workflow);
@@ -346,8 +333,6 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $workflow = $registry->get($subject);
 
         $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
-        $markingStoreProp->setAccessible(true);
-
         $markingStore = $markingStoreProp->getValue($workflow);
 
         $this->assertInstanceof(Workflow::class, $workflow);
@@ -359,11 +344,7 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $this->assertEquals('b', $subject->getState());
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider providesAutomaticMarkingStoreScenarios
-     */
+    #[DataProvider('providesAutomaticMarkingStoreScenarios')]
     public function testIfMarkingStoreIsAutomatic(array $typeConfig, bool $expectSingleState)
     {
         $config = [
@@ -388,8 +369,6 @@ class WorkflowRegistryTest extends BaseWorkflowTestCase
         $workflow = $registry->get($subject);
 
         $markingStoreProp = new ReflectionProperty(Workflow::class, 'markingStore');
-        $markingStoreProp->setAccessible(true);
-
         $markingStore = $markingStoreProp->getValue($workflow);
 
         $this->assertInstanceof(Workflow::class, $workflow);


### PR DESCRIPTION
- Add laravel 13 support
- Fix test files, two classes of PHP8.4 breaking changes
- Update Github action for laravel 13 testing
- Exclude PHP 8.1 on laravel 13.*