### PR TITLE
Fix deprecated getWorkflow Calls

### DIFF
--- a/src/Events/BaseEvent.php
+++ b/src/Events/BaseEvent.php
@@ -48,7 +48,7 @@ abstract class BaseEvent extends Event
             $symfonyEvent->getSubject(),
             $symfonyEvent->getMarking(),
             $symfonyEvent->getTransition(),
-            $symfonyEvent->getWorkflow()
+            Workflow::get($symfonyEvent->getSubject(), $symfonyEvent->getWorkflowName())
         );
     }
 }

--- a/src/Events/GuardEvent.php
+++ b/src/Events/GuardEvent.php
@@ -2,6 +2,7 @@
 
 namespace ZeroDaHero\LaravelWorkflow\Events;
 
+use Workflow;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\Event\Event;
@@ -43,7 +44,7 @@ class GuardEvent extends BaseEvent
             $this->getSubject(),
             $this->getMarking(),
             $this->getTransition(),
-            $this->getWorkflow()
+            Workflow::get($this->getSubject(), $this->getWorkflowName())
         );
     }
 
@@ -56,7 +57,7 @@ class GuardEvent extends BaseEvent
             $symfonyEvent->getSubject(),
             $symfonyEvent->getMarking(),
             $symfonyEvent->getTransition(),
-            $symfonyEvent->getWorkflow()
+            Workflow::get($symfonyEvent->getSubject(), $symfonyEvent->getWorkflowName())
         );
 
         $instance->symfonyProxyEvent = $symfonyEvent;


### PR DESCRIPTION
## Issue
Since symfony/workflow 7.3, Symfony\Component\Workflow\Event\Event::getWorkflow() is deprecated (message: "inject the workflow in the constructor where you need it"). The package still calls getWorkflow() in three spots, so the deprecation fires on every transition/guard evaluation. 

## Proposed Solution
This PR resolves the workflow via Workflow::get($subject, $workflowName) instead — the same non-deprecated pattern already used in BaseEvent::__unserialize().

This was taken off the Develop branch as this seems to be the main branch?  Please feel free to make any necessary corrections or even scrap and implement your own solution to this as necessary.